### PR TITLE
Update version of Jackson dependencies to 2.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Jackson
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.9.8'
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version:'2.9.8'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.9.8'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.10.1'
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version:'2.10.1'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.1'
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.0")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")


### PR DESCRIPTION
Purpose of update is to not use older version of jackson-databind, which
is susceptible to several security vulnerabilities. Relevant CVEs are:
 - CVE-2019-14540
 - CVE-2019-16335
 - CVE-2019-14379
 - CVE-2019-17531